### PR TITLE
Task/11355 & task/11592: Add PointerMapper to the scheduler & remove template parameter from the PointerMapper

### DIFF
--- a/utils/vptr/include/virtual_ptr.hpp
+++ b/utils/vptr/include/virtual_ptr.hpp
@@ -50,8 +50,8 @@ using buffer_data_type = uint8_t;
  *  Associates fake pointers with buffers.
  *
  */
-template <typename buffer_allocator =
-              cl::sycl::default_allocator<buffer_data_type> >
+//template <typename buffer_allocator =
+//              cl::sycl::default_allocator<buffer_data_type> >
 class PointerMapper {
  public:
   /* pointer information definitions
@@ -141,7 +141,8 @@ class PointerMapper {
 
   /* basic type for all buffers
    */
-  using buffer_t = cl::sycl::buffer<buffer_data_type, 1, buffer_allocator>;
+  //using buffer_t = cl::sycl::buffer<buffer_data_type, 1, buffer_allocator>;
+  using buffer_t = cl::sycl::buffer_mem;
 
   /**
    * Node that stores information about a device allocation.
@@ -393,11 +394,13 @@ class PointerMapper {
  * \param size Size in bytes of the desired allocation
  * \throw cl::sycl::exception if error while creating the buffer
  */
-template <typename PointerMapper>
+template <typename buffer_allocator =
+                   cl::sycl::default_allocator<buffer_data_type> >
 inline void *SYCLmalloc(size_t size, PointerMapper &pMap) {
   // Create a generic buffer of the given size
+  using buffer_t = cl::sycl::buffer<buffer_data_type, 1, buffer_allocator>;
   auto thePointer = pMap.add_pointer(
-      typename PointerMapper::buffer_t(cl::sycl::range<1>{size}));
+      buffer_t(cl::sycl::range<1>{size}));
   // Store the buffer on the global list
   return static_cast<void *>(thePointer);
 }

--- a/utils/vptr/include/virtual_ptr.hpp
+++ b/utils/vptr/include/virtual_ptr.hpp
@@ -225,12 +225,17 @@ class PointerMapper {
   }
 
   /* get_buffer.
-   * Returns a pointer to a buffer from the map using the pointer address
+   * Returns a buffer from the map using the pointer address
    */
   cl::sycl::buffer<buffer_data_type, 1, cl::sycl::detail::base_allocator>
   get_buffer(const virtual_pointer_t ptr) {
     using buffer_t =
         cl::sycl::buffer<buffer_data_type, 1, cl::sycl::detail::base_allocator>;
+
+    // get_node() returns a `buffer_mem`, so we need to cast it to a `buffer<>`.
+    // We can do this without the `buffer_mem` being a pointer, as we 
+    // only declare member variables in the base class (`buffer_mem`) and not in 
+    // the child class (`buffer<>).
     buffer_t buf(*(static_cast<buffer_t *>(&get_node(ptr)->second._b)));
     return buf;
   }

--- a/utils/vptr/include/virtual_ptr.hpp
+++ b/utils/vptr/include/virtual_ptr.hpp
@@ -44,15 +44,11 @@
 namespace codeplay {
 
 using buffer_data_type = uint8_t;
-using default_buffer_allocator = cl::sycl::default_allocator<buffer_data_type>;
-
 /**
  * PointerMapper
  *  Associates fake pointers with buffers.
  *
  */
-// template <typename buffer_allocator =
-//              cl::sycl::default_allocator<buffer_data_type> >
 class PointerMapper {
  public:
   /* pointer information definitions
@@ -142,7 +138,6 @@ class PointerMapper {
 
   /* basic type for all buffers
    */
-  // using buffer_t = cl::sycl::buffer<buffer_data_type, 1, buffer_allocator>;
   using buffer_t = cl::sycl::buffer_mem;
 
   /**
@@ -232,13 +227,12 @@ class PointerMapper {
   /* get_buffer.
    * Returns a pointer to a buffer from the map using the pointer address
    */
-  template <typename buffer_allocator = default_buffer_allocator>
-  cl::sycl::buffer<buffer_data_type, 1, buffer_allocator> get_buffer(
-      const virtual_pointer_t ptr) {
-    using buffer_t = cl::sycl::buffer<buffer_data_type, 1, buffer_allocator>;
-    auto buf = &get_node(ptr)->second._b;
-    buffer_t *b = static_cast<buffer_t *>(buf);
-    return *b;
+  cl::sycl::buffer<buffer_data_type, 1, cl::sycl::detail::base_allocator>
+  get_buffer(const virtual_pointer_t ptr) {
+    using buffer_t =
+        cl::sycl::buffer<buffer_data_type, 1, cl::sycl::detail::base_allocator>;
+    buffer_t buf(*(static_cast<buffer_t *>(&get_node(ptr)->second._b)));
+    return buf;
   }
 
   /*

--- a/utils/vptr/tests/CMakeLists.txt
+++ b/utils/vptr/tests/CMakeLists.txt
@@ -49,3 +49,14 @@ add_dependencies(offset gtest)
 add_sycl_to_target(offset  ${CMAKE_CURRENT_BINARY_DIR}
                     ${CMAKE_CURRENT_SOURCE_DIR}/offset.cc)
 add_test(OffsetTests offset)
+
+add_executable(scheduler scheduler.cc)
+set_property(TARGET scheduler PROPERTY CXX_STANDARD 11)
+target_link_libraries(scheduler PUBLIC ${gtest_BINARY_DIR}/libgtest.a)
+target_link_libraries(scheduler PUBLIC ${gtest_BINARY_DIR}/libgtest_main.a)
+target_link_libraries(scheduler PUBLIC pthread)
+add_dependencies(scheduler gtest_main)
+add_dependencies(scheduler gtest)
+add_sycl_to_target(scheduler  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/scheduler.cc)
+add_test(SchedulerTests scheduler)

--- a/utils/vptr/tests/basic.cc
+++ b/utils/vptr/tests/basic.cc
@@ -41,21 +41,22 @@ const sycl_acc_mode sycl_acc_rw = sycl_acc_mode::read_write;
 
 using namespace codeplay;
 
-using buffer_t = PointerMapper<>::buffer_t;
+using buffer_t = PointerMapper::buffer_t;
 
 TEST(pointer_mapper, basic_test) {
-  PointerMapper<> pMap;
+  PointerMapper pMap;
   {
     ASSERT_EQ(pMap.count(), 0u);
     void *myPtr = SYCLmalloc(100 * sizeof(float), pMap);
     ASSERT_NE(myPtr, nullptr);
 
-    ASSERT_FALSE(PointerMapper<>::is_nullptr(myPtr));
+    ASSERT_FALSE(PointerMapper::is_nullptr(myPtr));
 
-    ASSERT_TRUE(PointerMapper<>::is_nullptr(nullptr));
+    ASSERT_TRUE(PointerMapper::is_nullptr(nullptr));
 
     ASSERT_EQ(pMap.count(), 1u);
 
+    /* TODO(Vanya): uncomment this
     buffer_t b = pMap.get_buffer(myPtr);
 
     cl::sycl::queue q;
@@ -69,29 +70,31 @@ TEST(pointer_mapper, basic_test) {
       auto hostAcc = b.get_access<sycl_acc_rw, sycl_acc_host>();
       ASSERT_EQ(hostAcc[0], 1.0f);
     }
+    */
     SYCLfree(myPtr, pMap);
     ASSERT_EQ(pMap.count(), 0u);
   }
 }
 
 TEST(pointer_mapper, two_buffers) {
-  PointerMapper<> pMap;
+  PointerMapper pMap;
   {
     ASSERT_EQ(pMap.count(), 0u);
     void *ptrA = SYCLmalloc(100 * sizeof(int), pMap);
     ASSERT_NE(ptrA, nullptr);
-    ASSERT_FALSE(PointerMapper<>::is_nullptr(ptrA));
+    ASSERT_FALSE(PointerMapper::is_nullptr(ptrA));
     ASSERT_EQ(pMap.count(), 1u);
 
     void *ptrB = SYCLmalloc(10 * sizeof(int), pMap);
 
     ASSERT_NE(ptrB, nullptr);
-    ASSERT_FALSE(PointerMapper<>::is_nullptr(ptrA));
+    ASSERT_FALSE(PointerMapper::is_nullptr(ptrA));
     ASSERT_EQ(pMap.count(), 2u);
 
     // Obtain the buffer
     // Note that the scope of this buffer ends when the buffer
     // is freed
+    /* TODO(Vanya): Uncomment those
     try {
       buffer_t b2 = pMap.get_buffer(ptrB);
       buffer_t b1 = pMap.get_buffer(ptrA);
@@ -126,6 +129,7 @@ TEST(pointer_mapper, two_buffers) {
     } catch (std::out_of_range e) {
       FAIL();
     }
+    */
 
     ASSERT_EQ(pMap.count(), 2u);
     SYCLfree(ptrA, pMap);
@@ -136,26 +140,26 @@ TEST(pointer_mapper, two_buffers) {
 }
 
 TEST(pointer_mapper, reuse_ptr) {
-  PointerMapper<> pMap;
+  PointerMapper pMap;
   {
     ASSERT_EQ(pMap.count(), 0u);
 
     // First we insert a large buffer
     void *initial = SYCLmalloc(100 * sizeof(int), pMap);
     ASSERT_NE(initial, nullptr);
-    ASSERT_FALSE(PointerMapper<>::is_nullptr(initial));
+    ASSERT_FALSE(PointerMapper::is_nullptr(initial));
     ASSERT_EQ(pMap.count(), 1u);
 
     // Now we insert a small one, that we'll be reused
     void *reused = SYCLmalloc(10 * sizeof(int), pMap);
     ASSERT_NE(reused, nullptr);
-    ASSERT_FALSE(PointerMapper<>::is_nullptr(reused));
+    ASSERT_FALSE(PointerMapper::is_nullptr(reused));
     ASSERT_EQ(pMap.count(), 2u);
 
     // Another large buffer
     void *end = SYCLmalloc(100 * sizeof(int), pMap);
     ASSERT_NE(end, nullptr);
-    ASSERT_FALSE(PointerMapper<>::is_nullptr(end));
+    ASSERT_FALSE(PointerMapper::is_nullptr(end));
     ASSERT_EQ(pMap.count(), 3u);
 
     // We free the intermediate one
@@ -164,14 +168,14 @@ TEST(pointer_mapper, reuse_ptr) {
 
     void *shouldBeTheSame = SYCLmalloc(10 * sizeof(int), pMap);
     ASSERT_NE(shouldBeTheSame, nullptr);
-    ASSERT_FALSE(PointerMapper<>::is_nullptr(shouldBeTheSame));
+    ASSERT_FALSE(PointerMapper::is_nullptr(shouldBeTheSame));
     ASSERT_EQ(pMap.count(), 3u);
     ASSERT_EQ(shouldBeTheSame, reused);
   }
 }
 
 TEST(pointer_mapper, multiple_alloc_free) {
-  PointerMapper<> pMap;
+  PointerMapper pMap;
   size_t numAllocations = (1 << 9);
   size_t maxAllocSize = 1251;
 

--- a/utils/vptr/tests/basic.cc
+++ b/utils/vptr/tests/basic.cc
@@ -41,7 +41,10 @@ const sycl_acc_mode sycl_acc_rw = sycl_acc_mode::read_write;
 
 using namespace codeplay;
 
-using buffer_t = PointerMapper::buffer_t;
+// using buffer_t = PointerMapper::buffer_t;
+using buffer_t =
+    cl::sycl::buffer<buffer_data_type, 1,
+                     cl::sycl::default_allocator<buffer_data_type>>;
 
 TEST(pointer_mapper, basic_test) {
   PointerMapper pMap;
@@ -56,8 +59,7 @@ TEST(pointer_mapper, basic_test) {
 
     ASSERT_EQ(pMap.count(), 1u);
 
-    /* TODO(Vanya): uncomment this
-    buffer_t b = pMap.get_buffer(myPtr);
+    auto b = pMap.get_buffer(myPtr);
 
     cl::sycl::queue q;
     q.submit([&b](cl::sycl::handler &h) {
@@ -70,7 +72,6 @@ TEST(pointer_mapper, basic_test) {
       auto hostAcc = b.get_access<sycl_acc_rw, sycl_acc_host>();
       ASSERT_EQ(hostAcc[0], 1.0f);
     }
-    */
     SYCLfree(myPtr, pMap);
     ASSERT_EQ(pMap.count(), 0u);
   }
@@ -94,7 +95,6 @@ TEST(pointer_mapper, two_buffers) {
     // Obtain the buffer
     // Note that the scope of this buffer ends when the buffer
     // is freed
-    /* TODO(Vanya): Uncomment those
     try {
       buffer_t b2 = pMap.get_buffer(ptrB);
       buffer_t b1 = pMap.get_buffer(ptrA);
@@ -129,7 +129,6 @@ TEST(pointer_mapper, two_buffers) {
     } catch (std::out_of_range e) {
       FAIL();
     }
-    */
 
     ASSERT_EQ(pMap.count(), 2u);
     SYCLfree(ptrA, pMap);

--- a/utils/vptr/tests/basic.cc
+++ b/utils/vptr/tests/basic.cc
@@ -41,11 +41,6 @@ const sycl_acc_mode sycl_acc_rw = sycl_acc_mode::read_write;
 
 using namespace codeplay;
 
-// using buffer_t = PointerMapper::buffer_t;
-using buffer_t =
-    cl::sycl::buffer<buffer_data_type, 1,
-                     cl::sycl::default_allocator<buffer_data_type>>;
-
 TEST(pointer_mapper, basic_test) {
   PointerMapper pMap;
   {
@@ -96,8 +91,8 @@ TEST(pointer_mapper, two_buffers) {
     // Note that the scope of this buffer ends when the buffer
     // is freed
     try {
-      buffer_t b2 = pMap.get_buffer(ptrB);
-      buffer_t b1 = pMap.get_buffer(ptrA);
+      auto b2 = pMap.get_buffer(ptrB);
+      auto b1 = pMap.get_buffer(ptrA);
 
 #ifdef __COMPUTECPP__
       ASSERT_NE(b2.get_impl().get(), b1.get_impl().get());

--- a/utils/vptr/tests/offset.cc
+++ b/utils/vptr/tests/offset.cc
@@ -42,7 +42,7 @@ const sycl_acc_mode sycl_acc_rw = sycl_acc_mode::read_write;
 
 using namespace codeplay;
 
-using buffer_t = PointerMapper<>::buffer_t;
+using buffer_t = PointerMapper::buffer_t;
 
 struct kernel {
   using acc_type = cl::sycl::accessor<codeplay::buffer_data_type, 1,
@@ -64,19 +64,20 @@ struct kernel {
 };
 
 TEST(offset, basic_test) {
-  PointerMapper<> pMap;
+  PointerMapper pMap;
   {
     ASSERT_EQ(pMap.count(), 0u);
     float *myPtr = static_cast<float *>(SYCLmalloc(100 * sizeof(float), pMap));
 
     ASSERT_NE(myPtr, nullptr);
 
-    ASSERT_FALSE(PointerMapper<>::is_nullptr(myPtr));
+    ASSERT_FALSE(PointerMapper::is_nullptr(myPtr));
 
     ASSERT_EQ(pMap.count(), 1u);
 
     myPtr += 3;
 
+    /*TODO(Vanya): uncomment this
     buffer_t b = pMap.get_buffer(myPtr);
 
     size_t offset = pMap.get_offset(myPtr);
@@ -93,13 +94,14 @@ TEST(offset, basic_test) {
       auto hostAcc = b.get_access<sycl_acc_rw, sycl_acc_host>();
       ASSERT_EQ(hostAcc[offset], 1.0f);
     }
+    */
     SYCLfree(myPtr, pMap);
     ASSERT_EQ(pMap.count(), 0u);
   }
 }
 
 TEST(offset, 2d_indexing) {
-  PointerMapper<> pMap;
+  PointerMapper pMap;
   {
     const unsigned SIZE = 8;
     ASSERT_EQ(pMap.count(), 0u);
@@ -108,7 +110,7 @@ TEST(offset, 2d_indexing) {
 
     ASSERT_NE(myPtr, nullptr);
 
-    ASSERT_FALSE(PointerMapper<>::is_nullptr(myPtr));
+    ASSERT_FALSE(PointerMapper::is_nullptr(myPtr));
 
     ASSERT_EQ(pMap.count(), 1u);
 
@@ -121,6 +123,7 @@ TEST(offset, 2d_indexing) {
         // Note that the scope of this buffer ends when the buffer
         // is freed
         //
+        /* TODO(Vanya): uncomment this
         buffer_t b = pMap.get_buffer(actPos);
 
         size_t offset = pMap.get_offset(actPos);
@@ -130,6 +133,7 @@ TEST(offset, 2d_indexing) {
           auto accB = b.get_access<sycl_acc_rw>(h);
           h.single_task(kernel(accB, i, j, SIZE, offset));
         });
+        */
         // We move to the next ptr
         actPos++;
       }  // for int j
@@ -137,6 +141,7 @@ TEST(offset, 2d_indexing) {
 
     // Only way of reading the value is using a host accessor
     {
+      /* TODO(Vanya): uncomment this
       buffer_t b = pMap.get_buffer(myPtr);
       ASSERT_EQ(b.get_size(), SIZE * SIZE * sizeof(float));
       auto hostAcc = b.get_access<sycl_acc_rw, sycl_acc_host>();
@@ -146,6 +151,7 @@ TEST(offset, 2d_indexing) {
           ASSERT_EQ(fPtr[i * SIZE + j], i * SIZE + j);
         }
       }
+      */
     }
     SYCLfree(myPtr, pMap);
     ASSERT_EQ(pMap.count(), 0u);

--- a/utils/vptr/tests/offset.cc
+++ b/utils/vptr/tests/offset.cc
@@ -77,8 +77,7 @@ TEST(offset, basic_test) {
 
     myPtr += 3;
 
-    /*TODO(Vanya): uncomment this
-    buffer_t b = pMap.get_buffer(myPtr);
+    auto b = pMap.get_buffer(myPtr);
 
     size_t offset = pMap.get_offset(myPtr);
     ASSERT_EQ(offset, 3 * sizeof(float));
@@ -94,7 +93,7 @@ TEST(offset, basic_test) {
       auto hostAcc = b.get_access<sycl_acc_rw, sycl_acc_host>();
       ASSERT_EQ(hostAcc[offset], 1.0f);
     }
-    */
+
     SYCLfree(myPtr, pMap);
     ASSERT_EQ(pMap.count(), 0u);
   }
@@ -123,8 +122,7 @@ TEST(offset, 2d_indexing) {
         // Note that the scope of this buffer ends when the buffer
         // is freed
         //
-        /* TODO(Vanya): uncomment this
-        buffer_t b = pMap.get_buffer(actPos);
+        auto b = pMap.get_buffer(actPos);
 
         size_t offset = pMap.get_offset(actPos);
         ASSERT_EQ(offset, (i * SIZE + j) * sizeof(float));
@@ -133,7 +131,7 @@ TEST(offset, 2d_indexing) {
           auto accB = b.get_access<sycl_acc_rw>(h);
           h.single_task(kernel(accB, i, j, SIZE, offset));
         });
-        */
+
         // We move to the next ptr
         actPos++;
       }  // for int j
@@ -141,8 +139,7 @@ TEST(offset, 2d_indexing) {
 
     // Only way of reading the value is using a host accessor
     {
-      /* TODO(Vanya): uncomment this
-      buffer_t b = pMap.get_buffer(myPtr);
+      auto b = pMap.get_buffer(myPtr);
       ASSERT_EQ(b.get_size(), SIZE * SIZE * sizeof(float));
       auto hostAcc = b.get_access<sycl_acc_rw, sycl_acc_host>();
       float *fPtr = reinterpret_cast<float *>(&*hostAcc.get_pointer());
@@ -151,7 +148,6 @@ TEST(offset, 2d_indexing) {
           ASSERT_EQ(fPtr[i * SIZE + j], i * SIZE + j);
         }
       }
-      */
     }
     SYCLfree(myPtr, pMap);
     ASSERT_EQ(pMap.count(), 0u);

--- a/utils/vptr/tests/scheduler.cc
+++ b/utils/vptr/tests/scheduler.cc
@@ -1,0 +1,70 @@
+/***************************************************************************
+ *
+ *  Copyright (C) 2016 Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Codeplay's ComputeCpp SDK
+ *
+ *   basic.cc
+ *
+ *  Description:
+ *   Basic tests of the pointer mapper utility header
+ *
+ **************************************************************************/
+
+#include "gtest/gtest.h"
+
+#include <CL/sycl.hpp>
+#include <iostream>
+
+#include "virtual_ptr.hpp"
+#include "pointer_alias.hpp"
+
+using sycl_acc_target = cl::sycl::access::target;
+const sycl_acc_target sycl_acc_host = sycl_acc_target::host_buffer;
+
+using sycl_acc_mode = cl::sycl::access::mode;
+const sycl_acc_mode sycl_acc_rw = sycl_acc_mode::read_write;
+
+using namespace codeplay;
+
+TEST(pointer_mapper, basic_test) {
+
+  //Ensure that the pointer mapper in the runtime is null
+  auto runtime_pmppr_null = cl::sycl::detail::get_pointer_mapper();
+  ASSERT_TRUE(PointerMapper<>::is_nullptr(runtime_pmppr_null));
+
+  //Create a non-null pointer mapper
+  PointerMapper<> pMap;
+
+  ASSERT_EQ(pMap.count(), 0u);
+
+  void *myPtr = SYCLmalloc(100 * sizeof(float), pMap);
+  ASSERT_NE(myPtr, nullptr);
+
+  ASSERT_FALSE(PointerMapper<>::is_nullptr(myPtr));
+
+  ASSERT_TRUE(PointerMapper<>::is_nullptr(nullptr));
+
+  ASSERT_EQ(pMap.count(), 1u);
+
+  //Regiester it in the runtime
+  //cl::sycl::detail::register_pointer_mapper(pMap);
+
+  //Ensure that the pointer mapper in the runtime now isn't null
+  auto runtime_pmppr = cl::sycl::detail::get_pointer_mapper();
+  ASSERT_FALSE(PointerMapper<>::is_nullptr(runtime_pmppr));
+}

--- a/utils/vptr/tests/scheduler.cc
+++ b/utils/vptr/tests/scheduler.cc
@@ -45,26 +45,26 @@ TEST(pointer_mapper, basic_test) {
 
   //Ensure that the pointer mapper in the runtime is null
   auto runtime_pmppr_null = cl::sycl::detail::get_pointer_mapper();
-  ASSERT_TRUE(PointerMapper<>::is_nullptr(runtime_pmppr_null));
+  ASSERT_TRUE(PointerMapper::is_nullptr(runtime_pmppr_null));
 
   //Create a non-null pointer mapper
-  PointerMapper<> pMap;
+  PointerMapper pMap;
 
   ASSERT_EQ(pMap.count(), 0u);
 
   void *myPtr = SYCLmalloc(100 * sizeof(float), pMap);
   ASSERT_NE(myPtr, nullptr);
 
-  ASSERT_FALSE(PointerMapper<>::is_nullptr(myPtr));
+  ASSERT_FALSE(PointerMapper::is_nullptr(myPtr));
 
-  ASSERT_TRUE(PointerMapper<>::is_nullptr(nullptr));
+  ASSERT_TRUE(PointerMapper::is_nullptr(nullptr));
 
   ASSERT_EQ(pMap.count(), 1u);
 
   //Regiester it in the runtime
-  //cl::sycl::detail::register_pointer_mapper(pMap);
+  cl::sycl::detail::register_pointer_mapper(&pMap);
 
   //Ensure that the pointer mapper in the runtime now isn't null
   auto runtime_pmppr = cl::sycl::detail::get_pointer_mapper();
-  ASSERT_FALSE(PointerMapper<>::is_nullptr(runtime_pmppr));
+  ASSERT_FALSE(PointerMapper::is_nullptr(runtime_pmppr));
 }

--- a/utils/vptr/tests/scheduler.cc
+++ b/utils/vptr/tests/scheduler.cc
@@ -42,12 +42,11 @@ const sycl_acc_mode sycl_acc_rw = sycl_acc_mode::read_write;
 using namespace codeplay;
 
 TEST(pointer_mapper, basic_test) {
-
-  //Ensure that the pointer mapper in the runtime is null
+  // Ensure that the pointer mapper in the runtime is null
   auto runtime_pmppr_null = cl::sycl::detail::get_pointer_mapper();
   ASSERT_TRUE(PointerMapper::is_nullptr(runtime_pmppr_null));
 
-  //Create a non-null pointer mapper
+  // Create a non-null pointer mapper
   PointerMapper pMap;
 
   ASSERT_EQ(pMap.count(), 0u);
@@ -61,10 +60,10 @@ TEST(pointer_mapper, basic_test) {
 
   ASSERT_EQ(pMap.count(), 1u);
 
-  //Regiester it in the runtime
+  // Regiester it in the runtime
   cl::sycl::detail::register_pointer_mapper(&pMap);
 
-  //Ensure that the pointer mapper in the runtime now isn't null
+  // Ensure that the pointer mapper in the runtime now isn't null
   auto runtime_pmppr = cl::sycl::detail::get_pointer_mapper();
   ASSERT_FALSE(PointerMapper::is_nullptr(runtime_pmppr));
 }


### PR DESCRIPTION
This merge request relates to tasks 11355 and 11592.

We need to add a PointerMapper to the scheduler. This requires a forward declaration in the runtime. To do this, we need to remove the template argument to the PointerMapper.

* Removed the template argument to the PointerMapper class.
* Added it to methods `SYCLMalloc()` and `get_buffer()` instead.
* The buffers saved in the PointerMapper are saved as `buffer_mem` and statically casted to templated buffers in `get_buffer()`.
* Added a test for the new PointerMapper in the scheduler.