### PR TITLE
Added a template parameter for allocator to `get_buffer()`

### DIFF
--- a/utils/vptr/include/virtual_ptr.hpp
+++ b/utils/vptr/include/virtual_ptr.hpp
@@ -213,8 +213,7 @@ class PointerMapper {
   /* get_buffer.
    * Returns a buffer from the map using the pointer address
    */
-  template <
-      typename buffer_allocator = cl::sycl::default_allocator<buffer_data_type>>
+  template <typename buffer_allocator = cl::sycl::detail::base_allocator>
   cl::sycl::buffer<buffer_data_type, 1, buffer_allocator> get_buffer(
       const virtual_pointer_t ptr) {
     using buffer_t = cl::sycl::buffer<buffer_data_type, 1, buffer_allocator>;

--- a/utils/vptr/include/virtual_ptr.hpp
+++ b/utils/vptr/include/virtual_ptr.hpp
@@ -213,10 +213,11 @@ class PointerMapper {
   /* get_buffer.
    * Returns a buffer from the map using the pointer address
    */
-  cl::sycl::buffer<buffer_data_type, 1, cl::sycl::detail::base_allocator>
-  get_buffer(const virtual_pointer_t ptr) {
-    using buffer_t =
-        cl::sycl::buffer<buffer_data_type, 1, cl::sycl::detail::base_allocator>;
+  template <
+      typename buffer_allocator = cl::sycl::default_allocator<buffer_data_type>>
+  cl::sycl::buffer<buffer_data_type, 1, buffer_allocator> get_buffer(
+      const virtual_pointer_t ptr) {
+    using buffer_t = cl::sycl::buffer<buffer_data_type, 1, buffer_allocator>;
 
     // get_node() returns a `buffer_mem`, so we need to cast it to a `buffer<>`.
     // We can do this without the `buffer_mem` being a pointer, as we
@@ -430,7 +431,7 @@ class PointerMapper {
  * \throw cl::sycl::exception if error while creating the buffer
  */
 template <
-    typename buffer_allocator = cl::sycl::default_allocator<buffer_data_type> >
+    typename buffer_allocator = cl::sycl::default_allocator<buffer_data_type>>
 inline void *SYCLmalloc(size_t size, PointerMapper &pMap) {
   // Create a generic buffer of the given size
   using buffer_t = cl::sycl::buffer<buffer_data_type, 1, buffer_allocator>;

--- a/utils/vptr/tests/accessor.cc
+++ b/utils/vptr/tests/accessor.cc
@@ -129,10 +129,20 @@ TEST(accessor, allocator) {
   {
     ASSERT_EQ(pMap.count(), 0u);
 
-    // add a pointer with the allocator type
+    // add a pointer with the base allocator type
     void *ptrA = SYCLmalloc(100 * sizeof(int), pMap);
 
+    // get the buffer with the base allocator type
+    auto bufA = pMap.get_buffer(ptrA);
+
+    ASSERT_EQ(pMap.count(), 1u);
+
+    // add a pointer with the allocator type
+    void *ptrB = SYCLmalloc<alloc_t>(100 * sizeof(int), pMap);
+
     // get the buffer with the allocator type
-    cl::sycl::buffer<uint8_t, 1, alloc_t> buf = pMap.get_buffer(ptrA);
+    cl::sycl::buffer<uint8_t, 1, alloc_t> bufB = pMap.get_buffer<alloc_t>(ptrB);
+
+    ASSERT_EQ(pMap.count(), 2u);
   }
 }

--- a/utils/vptr/tests/accessor.cc
+++ b/utils/vptr/tests/accessor.cc
@@ -120,3 +120,19 @@ TEST(accessor, two_buffers) {
     ASSERT_EQ(pMap.count(), 0u);
   }
 }
+
+TEST(accessor, allocator) {
+  // an allocator type
+  using alloc_t = cl::sycl::detail::aligned_mem::aligned_allocator<uint8_t>;
+
+  PointerMapper pMap;
+  {
+    ASSERT_EQ(pMap.count(), 0u);
+
+    // add a pointer with the allocator type
+    void *ptrA = SYCLmalloc(100 * sizeof(int), pMap);
+
+    // get the buffer with the allocator type
+    cl::sycl::buffer<uint8_t, 1, alloc_t> buf = pMap.get_buffer(ptrA);
+  }
+}


### PR DESCRIPTION
This pull request contains:

- a new template parameter for the allocator type to `get_buffer()`

- a test in accessor.cc